### PR TITLE
fix: send email code even when the email is verified

### DIFF
--- a/src/auth/service/auth.service.ts
+++ b/src/auth/service/auth.service.ts
@@ -217,9 +217,6 @@ export class AuthService {
       throw new NotFoundException('User not found');
     }
 
-    if (user.isEmailVerified) {
-      throw new BadRequestException('Email already verified');
-    }
     await this.sendEmailVerificationCode(email);
   }
 


### PR DESCRIPTION
* Because we're using verification codes for logins and signup, doesn't matter if email is verified. The code should be sent